### PR TITLE
Dictionary link updated

### DIFF
--- a/Courses/Fundamentals.md
+++ b/Courses/Fundamentals.md
@@ -6,7 +6,7 @@
 - Канал в телеграме: https://t.me/HowProgrammingWorks
 - Группа (чат): https://t.me/Programming_IP9X
 - Задачи по курсу: https://github.com/HowProgrammingWorks/Index/blob/master/Exercises.ru.md
-- Словарь терминов: https://github.com/HowProgrammingWorks/Dictionary/blob/master/IP9X.ru.md
+- Словарь терминов: https://github.com/HowProgrammingWorks/Dictionary
 
 ## 1 семестр
 


### PR DESCRIPTION
The previous link is broken and refers to nonexistent page.


![photo_2020-01-06_20-17-34](https://user-images.githubusercontent.com/35728917/71838474-91227f80-30c1-11ea-86d5-04be1000b3b3.jpg)
