### PR TITLE
Update GRASP topic and links

### DIFF
--- a/Courses/GRASP.md
+++ b/Courses/GRASP.md
@@ -2,6 +2,10 @@
 
 - [GRASP принципы с адаптацией для JavaScript и Node.js](https://youtu.be/ExauFjYV_lQ)
 - [Принцип информационный эксперт / Information Expert](https://youtu.be/cCHL329_As0)
+  - Примеры кода: https://github.com/HowProgrammingWorks/InformationExpert
 - [Зацепление и связность / Coupling and Cohesion](https://youtu.be/IGXdPOZ3Fyk)
+  - Примеры кода: https://github.com/HowProgrammingWorks/CouplingCohesion
 - [Чистая выдумка / Pure Fabrication](https://youtu.be/CV577a0RHBM)
+  - Примеры кода: https://github.com/HowProgrammingWorks/PureFabrication
 - [Пример декомпозиции класса](https://youtu.be/4AMVQ2-2DcM)
+  - Примеры кода: https://github.com/metarhia/impress/blob/v2.0.0/lib/application.js

--- a/Courses/NodeJS.md
+++ b/Courses/NodeJS.md
@@ -38,7 +38,7 @@
   - Слайды: https://www.slideshare.net/tshemsedinov/nodejs-in-2019
 - [Асинхронное программирование в Node.js](https://youtu.be/hY6Z6qNYzmc)
   - Это только обзорная лекция, ссылка на курс по асинхронному программированию
-  находится выше, перед оглавлением
+    находится выше, перед оглавлением
 - [Обзор встроенного Node.js API](https://youtu.be/sOkjR-N6IAs)
   - Ссылка на документацию: https://nodejs.org/api/documentation.html
 - [Настройка среды: Node.js, npm, git, eslint](https://youtu.be/hSyA7tcNaCE)
@@ -71,11 +71,7 @@
   - Примеры кода: https://github.com/HowProgrammingWorks/InterProcessCommunication
 - [Слои, связанность и связность кода](https://youtu.be/A3RpwNlVeyY)
   - Примеры кода: https://github.com/HowProgrammingWorks/Abstractions
-- [GRASP принципы с адаптацией для JavaScript и Node.js](https://youtu.be/ExauFjYV_lQ)
-- [Принцип информационный эксперт / Information Expert](https://youtu.be/cCHL329_As0)
-- [Зацепление и связность / coupling and cohesion](https://youtu.be/IGXdPOZ3Fyk)
-- [Чистая выдумка / Pure Fabrication](https://youtu.be/CV577a0RHBM)
-- [GRASP: Пример декомпозиции класса](https://youtu.be/4AMVQ2-2DcM)
+- [GRASP принципы](https://github.com/HowProgrammingWorks/Index/blob/master/Courses/GRASP.md)
 
 ## Разработка серверов приложений и API на Node.js
 
@@ -130,7 +126,7 @@
   - Семафоры: https://github.com/HowProgrammingWorks/Semaphore
   - Мьютексы: https://github.com/HowProgrammingWorks/Mutex
 - [Разделяемая память в многопоточном Node.js](https://youtu.be/KNsm_iIQt7U) -
-доклад на конференции JS Fest 2019 Spring
+  доклад на конференции JS Fest 2019 Spring
   - Слайды: https://www.slideshare.net/JSFestUA/js-fest-2019-nodejs
 - [Web Locks API in Node.js and browser](https://youtu.be/auMM-uV12F0)
   - Слайды: https://www.slideshare.net/tshemsedinov/web-locks-api

--- a/Courses/OOP.md
+++ b/Courses/OOP.md
@@ -23,3 +23,7 @@
 - [Антипаттерны объектно-ориентированного программирования](https://youtu.be/9d5TG1VsLeU)
   - Примеры кода: https://github.com/HowProgrammingWorks/Antipatterns/tree/master/JavaScript/03-OOP
 - [GRASP принципы](https://github.com/HowProgrammingWorks/Index/blob/master/Courses/GRASP.md)
+  - Принцип информационный эксперт / Information Expert
+  - Зацепление и связность / Coupling and Cohesion
+  - Чистая выдумка / Pure Fabrication
+  - Пример декомпозиции класса

--- a/Courses/OOP.md
+++ b/Courses/OOP.md
@@ -22,8 +22,4 @@
   - Примеры кода: https://github.com/HowProgrammingWorks/LiskovSubstitution
 - [Антипаттерны объектно-ориентированного программирования](https://youtu.be/9d5TG1VsLeU)
   - Примеры кода: https://github.com/HowProgrammingWorks/Antipatterns/tree/master/JavaScript/03-OOP
-- [GRASP принципы с адаптацией для JavaScript и Node.js](https://youtu.be/ExauFjYV_lQ)
-- [Принцип информационный эксперт / Information Expert](https://youtu.be/cCHL329_As0)
-- [Зацепление и связность / coupling and cohesion](https://youtu.be/IGXdPOZ3Fyk)
-- [Чистая выдумка / Pure Fabrication](https://youtu.be/CV577a0RHBM)
-- [GRASP: Пример декомпозиции класса](https://youtu.be/4AMVQ2-2DcM)
+- [GRASP принципы](https://github.com/HowProgrammingWorks/Index/blob/master/Courses/GRASP.md)


### PR DESCRIPTION
- add missing links to code examples in _GRASP_ topic
- separate the _GRASP_ links from _OOP_ and _NodeJS_ topics

I think, we should separate the "GRASP" links for better structure and maintaining.